### PR TITLE
Fixes #33 (default link icon instead of `undefined`)

### DIFF
--- a/template.js
+++ b/template.js
@@ -195,8 +195,9 @@
       const proofs = await getUser(user, 'hackernews');
       for (const {proof_type, nametag, service_url} of proofs.slice().reverse()) {
         if (proof_type === 'hackernews' || (proof_type !== 'keybase' && keybaseBadgeOnly)) continue;
+        const icon = icons[proof_type] || icons.generic_web_site;
         element.insertAdjacentHTML('afterend', `
-          <a href="${service_url}" rel="noreferrer noopener"><span style="${getStyle()}">${icons[proof_type]}</span></a>`);
+          <a href="${service_url}" rel="noreferrer noopener"><span style="${getStyle()}">${icon}</span></a>`);
       }
     }
   }


### PR DESCRIPTION
Hi @dschep, 
This PR stops then `undefined` value from showing up on the page, would really appreciate it if this gets deployed 🙏 

## Before
![image](https://user-images.githubusercontent.com/11782590/162927459-da179882-03ec-48ab-8dd9-1b01bc31b4fd.png)

## After
![image](https://user-images.githubusercontent.com/11782590/162928137-7be43f03-c471-41eb-9dab-b277b38b1d62.png)

I use this extension every now and then, and I'm thankful it exists ❤️ 